### PR TITLE
Add initial state with link to estimate shipping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,19 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Initial state with link to show delivery options.
+
 ## [0.1.1] - 2019-08-21
 
 ## Fixed
 
-- Container styles;
+- Container styles.
 
 ## Added
 
-- Default props with new address if it does not come from props
+- Default props with new address if it does not come from props.
 
 ## [0.1.0] - 2019-08-20
 

--- a/messages/context.json
+++ b/messages/context.json
@@ -2,5 +2,6 @@
   "store/shipping-calculator.delivery": "Delivery",
   "store/shipping-calculator.deliveryFor": "Delivery for",
   "store/shipping-calculator.edit": "edit",
-  "store/shipping-calculator.estimate": "estimate"
+  "store/shipping-calculator.estimate": "estimate",
+  "store/shipping-calculator.viewDeliveryOptions": "View delivery options"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -2,5 +2,6 @@
   "store/shipping-calculator.delivery": "Delivery",
   "store/shipping-calculator.deliveryFor": "Delivery for",
   "store/shipping-calculator.edit": "edit",
-  "store/shipping-calculator.estimate": "estimate"
+  "store/shipping-calculator.estimate": "estimate",
+  "store/shipping-calculator.viewDeliveryOptions": "View delivery options"
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -2,5 +2,6 @@
   "store/shipping-calculator.delivery": "Entrega",
   "store/shipping-calculator.deliveryFor": "Entrega en",
   "store/shipping-calculator.edit": "cambiar",
-  "store/shipping-calculator.estimate": "calcular"
+  "store/shipping-calculator.estimate": "calcular",
+  "store/shipping-calculator.viewDeliveryOptions": "Ver opciones de entrega"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -2,5 +2,6 @@
   "store/shipping-calculator.delivery": "Entrega",
   "store/shipping-calculator.deliveryFor": "Entrega em",
   "store/shipping-calculator.edit": "editar",
-  "store/shipping-calculator.estimate": "calcular"
+  "store/shipping-calculator.estimate": "calcular",
+  "store/shipping-calculator.viewDeliveryOptions": "Ver opções de entrega"
 }

--- a/react/ShippingCalculator.tsx
+++ b/react/ShippingCalculator.tsx
@@ -1,24 +1,22 @@
 import React, { useState, FunctionComponent } from 'react'
-import PostalCode from './components/PostalCode'
-import ShippingResult from './components/ShippingResult'
 import styles from './styles.css'
-import { useRuntime } from 'vtex.render-runtime'
 import { FormattedMessage, defineMessages } from 'react-intl'
-import { components, helpers } from 'vtex.address-form'
-import { newAddress } from './utils/address'
-const { AddressContainer, AddressRules, StyleguideInput } = components
-const { addValidation } = helpers
+import { Button } from 'vtex.styleguide'
+import EstimateShipping from './components/EstimateShipping'
 
 defineMessages({
   delivery: {
     defaultMessage: 'Delivery',
     id: 'store/shipping-calculator.delivery',
   },
+  viewDeliveryOptions: {
+    defaultMessage: 'View delivery options',
+    id: 'store/shipping-calculator.viewDeliveryOptions',
+  },
 })
 
 type CustomProps = {
   selectedAddress: Address
-  accountName: string
   deliveryOptions: DeliveryOption[]
   countries: string[]
 }
@@ -28,55 +26,32 @@ const ShippingCalculator: FunctionComponent<CustomProps> = ({
   deliveryOptions,
   countries,
 }) => {
-  const { account, culture } = useRuntime()
-
-  const [address, setAddress] = useState<AddressWithValidation>(
-    addValidation(selectedAddress || newAddress({ country: culture.country }))
+  const [showEstimateShipping, setShowEstimateShipping] = useState<boolean>(
+    deliveryOptions.length > 0
   )
 
-  const [showResult, setShowResult] = useState<boolean>(false)
-
-  const handleAddressChange = (address: AddressWithValidation) => {
-    setAddress(address)
-  }
-
-  const handleSubmit = () => {
-    const postalCodeValid =
-      address && address.postalCode && address.postalCode.valid
-    const geoCoordinatesValid =
-      address && address.geoCoordinates && address.geoCoordinates.valid
-
-    if (postalCodeValid || geoCoordinatesValid) {
-      setShowResult(true)
-    }
-  }
-
   return (
-    <div className={`${styles.container} flex flex-column pv6`}>
+    <div className={`${styles.container} flex flex-column pt6`}>
       <p className="t-heading-5 c-on-muted-3">
         <FormattedMessage id="store/shipping-calculator.delivery" />
       </p>
-      <AddressRules
-        country={address.country && address.country.value}
-        shouldUseIOFetching
-      >
-        <AddressContainer
-          accountName={account}
-          address={address}
-          Input={StyleguideInput}
-          onChangeAddress={handleAddressChange}
-        >
-          {showResult ? (
-            <ShippingResult
-              address={address}
-              options={deliveryOptions}
-              setShowResult={setShowResult}
-            />
-          ) : (
-            <PostalCode handleSubmit={handleSubmit} countries={countries} />
-          )}
-        </AddressContainer>
-      </AddressRules>
+      {showEstimateShipping ? (
+        <EstimateShipping
+          selectedAddress={selectedAddress}
+          deliveryOptions={deliveryOptions}
+          countries={countries}
+        />
+      ) : (
+        <div className="mb5">
+          <Button
+            variation="tertiary"
+            collapseLeft
+            onClick={() => setShowEstimateShipping(true)}
+          >
+            <FormattedMessage id="store/shipping-calculator.viewDeliveryOptions" />
+          </Button>
+        </div>
+      )}
     </div>
   )
 }

--- a/react/components/EstimateShipping.tsx
+++ b/react/components/EstimateShipping.tsx
@@ -1,0 +1,74 @@
+import React, { useState, FunctionComponent } from 'react'
+import PostalCode from './PostalCode'
+import ShippingResult from './ShippingResult'
+import { useRuntime } from 'vtex.render-runtime'
+import { components, helpers } from 'vtex.address-form'
+import { newAddress } from '../utils/address'
+const { AddressContainer, AddressRules, StyleguideInput } = components
+const { addValidation } = helpers
+
+type CustomProps = {
+  selectedAddress: Address
+  deliveryOptions: DeliveryOption[]
+  countries: string[]
+}
+
+const EstimateShipping: FunctionComponent<CustomProps> = ({
+  selectedAddress,
+  deliveryOptions,
+  countries,
+}) => {
+  const { account, culture } = useRuntime()
+
+  const [address, setAddress] = useState<AddressWithValidation>(
+    addValidation(selectedAddress || newAddress({ country: culture.country }))
+  )
+
+  const [showResult, setShowResult] = useState<boolean>(false)
+
+  const handleAddressChange = (address: AddressWithValidation) => {
+    setAddress(address)
+  }
+
+  const handleSubmit = () => {
+    const postalCodeValid =
+      address && address.postalCode && address.postalCode.valid
+    const geoCoordinatesValid =
+      address && address.geoCoordinates && address.geoCoordinates.valid
+
+    if (postalCodeValid || geoCoordinatesValid) {
+      setShowResult(true)
+    }
+  }
+
+  return (
+    <AddressRules
+      country={address.country && address.country.value}
+      shouldUseIOFetching
+    >
+      <AddressContainer
+        accountName={account}
+        address={address}
+        Input={StyleguideInput}
+        onChangeAddress={handleAddressChange}
+      >
+        {showResult ? (
+          <ShippingResult
+            address={address}
+            options={deliveryOptions}
+            setShowResult={setShowResult}
+          />
+        ) : (
+          <PostalCode handleSubmit={handleSubmit} countries={countries} />
+        )}
+      </AddressContainer>
+    </AddressRules>
+  )
+}
+
+EstimateShipping.defaultProps = {
+  countries: [],
+  deliveryOptions: [],
+}
+
+export default EstimateShipping


### PR DESCRIPTION
#### What problem is this solving?

Add initial state with link to estimate shipping

Closes [story](https://app.clubhouse.io/vtex/story/18571/implementar-empty-state-do-shipping-calculator) 
#### How should this be manually tested?

[Workspace](url)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage
<img width="290" alt="Screen Shot 2019-08-22 at 22 30 07" src="https://user-images.githubusercontent.com/5608421/63595541-98704300-c58f-11e9-8317-d7cf79d00b5e.png">


#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
