### PR TITLE
Add autoFocus to PostalCodeGetter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,20 +7,24 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- `PostalCodeGetter` with `autoFocus` now.
+
 ## [0.3.0] - 2019-10-10
 
-## Added
+### Added
 
 - Selects a delivery option.
 - Estimates shipping value.
 
-## Changed
+### Changed
 
 - Title and postal code margin values.
 
 ## [0.2.1] - 2019-08-23
 
-## Fixed
+### Fixed
 
 - Some element margins.
 
@@ -32,17 +36,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [0.1.1] - 2019-08-21
 
-## Fixed
+### Fixed
 
 - Container styles.
 
-## Added
+### Added
 
 - Default props with new address if it does not come from props.
 
 ## [0.1.0] - 2019-08-20
 
-## Added
+### Added
 
 - Component blocks setup;
 - Initial component with postalCode calculator;

--- a/react/components/PostalCode.tsx
+++ b/react/components/PostalCode.tsx
@@ -50,6 +50,7 @@ const PostalCode: FunctionComponent<Props> = ({
         Button={StyleguideButton}
         submitLabel={getSubmitMessage()}
         onSubmit={handleSubmit}
+        autoFocus
       />
     </Fragment>
   )


### PR DESCRIPTION
#### What problem is this solving?

This PR solves the lack of auto focus on postal code input. 

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

- Go to [Workspace](https://ordershipping--vtexgame1.myvtex.com/cart).
- Click on "Alterar".
- Check if input is being focused.


#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] [Linked this PR to a Clubhouse story (if applicable).](https://app.clubhouse.io/vtex/story/24049/fix-styleguideinput-sem-autofocus)
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/12574426/66778687-d3fa0000-eea2-11e9-9278-5236ae3c06ca.png)


#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️| Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
