### PR TITLE
Add ids to the styleguide components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `id` to the styleguide components.
+
 ## [0.3.1] - 2019-10-15
 
 ### Fixed

--- a/react/ShippingCalculator.tsx
+++ b/react/ShippingCalculator.tsx
@@ -45,6 +45,7 @@ const ShippingCalculator: FunctionComponent = () => {
       ) : (
         <div className="mt3">
           <Button
+            id="view-delivery-options"
             variation="tertiary"
             collapseLeft
             noUpperCase

--- a/react/components/PostalCode.tsx
+++ b/react/components/PostalCode.tsx
@@ -44,9 +44,10 @@ const PostalCode: FunctionComponent<Props> = ({
   return (
     <Fragment>
       {translatedCountries.length > 1 && (
-        <CountrySelector shipsTo={translatedCountries} />
+        <CountrySelector id="country-selector" shipsTo={translatedCountries} />
       )}
       <PostalCodeGetter
+        id="postal-code-getter"
         Button={StyleguideButton}
         submitLabel={getSubmitMessage()}
         onSubmit={handleSubmit}

--- a/react/components/ShippingInfo.tsx
+++ b/react/components/ShippingInfo.tsx
@@ -12,11 +12,17 @@ const ShippingInfo: FunctionComponent<CustomProps> = ({ option }) => {
       <div className="flex-auto">
         <div className="mb3">{option.id}</div>
         <div className="c-muted-1">
-          <TranslateEstimate shippingEstimate={option.estimate} />
+          <TranslateEstimate
+            id="translate-estimate"
+            shippingEstimate={option.estimate}
+          />
         </div>
       </div>
       <div className="flex-none">
-        <FormattedCurrency value={option.price / 100} />
+        <FormattedCurrency
+          id={`${option.id}-price`}
+          value={option.price / 100}
+        />
       </div>
     </div>
   )

--- a/react/components/ShippingResult.tsx
+++ b/react/components/ShippingResult.tsx
@@ -42,6 +42,7 @@ const ShippingResult: FunctionComponent<CustomProps> = ({
         </div>
         <div className="flex-none">
           <Button
+            id="edit-shipping"
             collapseRight
             variation="tertiary"
             onClick={() => setShowResult(false)}


### PR DESCRIPTION
#### What problem is this solving?

In order to do the e2e tests, the elements need to have identifiers. This PR does it.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

[Workspace](https://testid--vtexgame1.myvtex.com/cart)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] [Linked this PR to a Clubhouse story (if applicable).](https://app.clubhouse.io/vtex/story/24034/adicionar-atributo-testid-em-elementos-da-ui)
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
✔️ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
