### PR TITLE
Fix invalid postal code being accepted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Invalid postal code being accepted.
+
 ## [0.3.3] - 2019-10-23
 
 ### Added

--- a/react/components/EstimateShipping.tsx
+++ b/react/components/EstimateShipping.tsx
@@ -45,10 +45,8 @@ const EstimateShipping: FunctionComponent<CustomProps> = ({
     const addressWithoutValidation = removeValidation(address)
     const postalCodeValid =
       address && address.postalCode && address.postalCode.valid
-    const geoCoordinatesValid =
-      address && address.geoCoordinates && address.geoCoordinates.valid
 
-    if (postalCodeValid || geoCoordinatesValid) {
+    if (postalCodeValid) {
       insertAddress(addressWithoutValidation)
       setShowResult(true)
     }


### PR DESCRIPTION
#### What problem is this solving?

Currently, even an invalid postal code is being accepted. This happens because we were not considering the case when a **valid** postal code is inserted (and so, has valid geo coordinates) and, after that, it is edited to an **invalid** one, but it still has valid geo coordinates saved on the `address` object.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

- Go to [Workspace](https://productskeleton--checkoutio.myvtex.com/cart)
- Type a valid postal code (e.g. 22230-001)
- Then edit it to an invalid one (e.g. 22230-001sss)
- Verify that its not being accepted anymore

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] [Linked this PR to a Clubhouse story (if applicable).](https://app.clubhouse.io/vtex/story/25041/somente-ir-para-delivery-options-se-o-c%C3%B3digo-postal-estiver-valido)
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/12574426/67703442-33bbd500-f992-11e9-90e9-65e1b662b161.png)


#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

