### PR TITLE
Add preview skeleton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `blocks` file in order to pass children components to `Shipping`.
+- `estimate-shipping` interface with `preview` property for skeleton purposes.
+
+### Changed
+
+- Receives the necessary shipping data through props.
+- Add preview skeleton
+
 ## [0.3.4] - 2019-10-29
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - `blocks` file in order to pass children components to `Shipping`.
 - `estimate-shipping` interface with `preview` property for skeleton purposes.
+- Preview skeleton.
 
 ### Changed
 
 - Receives the necessary shipping data through props.
-- Add preview skeleton
 
 ## [0.3.4] - 2019-10-29
 

--- a/manifest.json
+++ b/manifest.json
@@ -20,8 +20,7 @@
     "vtex.country-codes": "2.x",
     "vtex.format-currency": "0.x",
     "vtex.styleguide": "9.x",
-    "vtex.shipping-estimate-translator": "2.x",
-    "vtex.order-shipping": "0.x"
+    "vtex.shipping-estimate-translator": "2.x"
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/react/Shipping.tsx
+++ b/react/Shipping.tsx
@@ -1,0 +1,77 @@
+import React, {
+  createContext,
+  useContext,
+  FunctionComponent,
+  ReactNode,
+} from 'react'
+import { FormattedMessage, defineMessages } from 'react-intl'
+
+defineMessages({
+  delivery: {
+    defaultMessage: 'Delivery',
+    id: 'store/shipping-calculator.delivery',
+  },
+})
+
+interface Context {
+  countries: string[]
+  deliveryOptions: DeliveryOption[]
+  insertAddress: (address: CheckoutAddress) => void
+  selectDeliveryOption: (option: string) => void
+  selectedAddress: Address
+}
+
+const ShippingContext = createContext<Context | undefined>(undefined)
+
+export const useShipping = () => {
+  const context = useContext(ShippingContext)
+  if (context === undefined) {
+    throw new Error('useShipping must be used within a ShippingProvider')
+  }
+
+  return context
+}
+
+const Shipping: FunctionComponent<ShippingProps> = ({
+  children,
+  countries,
+  deliveryOptions,
+  insertAddress,
+  selectDeliveryOption,
+  selectedAddress,
+}) => {
+  return (
+    <ShippingContext.Provider
+      value={{
+        countries,
+        deliveryOptions,
+        insertAddress,
+        selectDeliveryOption,
+        selectedAddress,
+      }}
+    >
+      <div className="flex flex-column c-on-base">
+        <h5 className="t-heading-5 mt0 mb3">
+          <FormattedMessage id="store/shipping-calculator.delivery" />
+        </h5>
+        {children}
+      </div>
+    </ShippingContext.Provider>
+  )
+}
+
+Shipping.defaultProps = {
+  countries: [],
+  deliveryOptions: [],
+}
+
+interface ShippingProps {
+  children: ReactNode
+  countries: string[]
+  deliveryOptions: DeliveryOption[]
+  insertAddress: (address: CheckoutAddress) => void
+  selectDeliveryOption: (option: string) => void
+  selectedAddress: Address
+}
+
+export default Shipping

--- a/react/Shipping.tsx
+++ b/react/Shipping.tsx
@@ -17,6 +17,7 @@ interface Context {
   countries: string[]
   deliveryOptions: DeliveryOption[]
   insertAddress: (address: CheckoutAddress) => void
+  loading: boolean
   selectDeliveryOption: (option: string) => void
   selectedAddress: Address
 }
@@ -37,6 +38,7 @@ const Shipping: FunctionComponent<ShippingProps> = ({
   countries,
   deliveryOptions,
   insertAddress,
+  loading,
   selectDeliveryOption,
   selectedAddress,
 }) => {
@@ -46,6 +48,7 @@ const Shipping: FunctionComponent<ShippingProps> = ({
         countries,
         deliveryOptions,
         insertAddress,
+        loading,
         selectDeliveryOption,
         selectedAddress,
       }}
@@ -70,6 +73,7 @@ interface ShippingProps {
   countries: string[]
   deliveryOptions: DeliveryOption[]
   insertAddress: (address: CheckoutAddress) => void
+  loading: boolean
   selectDeliveryOption: (option: string) => void
   selectedAddress: Address
 }

--- a/react/Shipping.tsx
+++ b/react/Shipping.tsx
@@ -27,7 +27,7 @@ const ShippingContext = createContext<Context | undefined>(undefined)
 export const useShipping = () => {
   const context = useContext(ShippingContext)
   if (context === undefined) {
-    throw new Error('useShipping must be used within a ShippingProvider')
+    throw new Error('useShipping must be used within a Shipping component')
   }
 
   return context

--- a/react/ShippingCalculator.tsx
+++ b/react/ShippingCalculator.tsx
@@ -2,14 +2,9 @@ import React, { useState, FunctionComponent } from 'react'
 import { FormattedMessage, defineMessages } from 'react-intl'
 import { Button } from 'vtex.styleguide'
 import EstimateShipping from './components/EstimateShipping'
-
-import { useOrderShipping } from 'vtex.order-shipping/OrderShipping'
+import { useShipping } from './Shipping'
 
 defineMessages({
-  delivery: {
-    defaultMessage: 'Delivery',
-    id: 'store/shipping-calculator.delivery',
-  },
   viewDeliveryOptions: {
     defaultMessage: 'View delivery options',
     id: 'store/shipping-calculator.viewDeliveryOptions',
@@ -18,22 +13,19 @@ defineMessages({
 
 const ShippingCalculator: FunctionComponent = () => {
   const {
-    insertAddress,
-    selectedAddress,
-    deliveryOptions,
     countries,
+    deliveryOptions,
+    insertAddress,
     selectDeliveryOption,
-  } = useOrderShipping()
+    selectedAddress,
+  } = useShipping()
 
   const [showEstimateShipping, setShowEstimateShipping] = useState<boolean>(
     selectedAddress && selectedAddress.postalCode ? true : false
   )
 
   return (
-    <div className="flex flex-column c-on-base">
-      <h5 className="t-heading-5 mt0 mb3">
-        <FormattedMessage id="store/shipping-calculator.delivery" />
-      </h5>
+    <div>
       {showEstimateShipping ? (
         <EstimateShipping
           selectedAddress={selectedAddress}
@@ -57,11 +49,6 @@ const ShippingCalculator: FunctionComponent = () => {
       )}
     </div>
   )
-}
-
-ShippingCalculator.defaultProps = {
-  countries: [],
-  deliveryOptions: [],
 }
 
 export default ShippingCalculator

--- a/react/ShippingCalculator.tsx
+++ b/react/ShippingCalculator.tsx
@@ -1,6 +1,7 @@
 import React, { useState, FunctionComponent } from 'react'
 import { FormattedMessage, defineMessages } from 'react-intl'
 import { Button } from 'vtex.styleguide'
+import { Loading } from 'vtex.render-runtime'
 import EstimateShipping from './components/EstimateShipping'
 import { useShipping } from './Shipping'
 
@@ -16,6 +17,7 @@ const ShippingCalculator: FunctionComponent = () => {
     countries,
     deliveryOptions,
     insertAddress,
+    loading,
     selectDeliveryOption,
     selectedAddress,
   } = useShipping()
@@ -23,6 +25,10 @@ const ShippingCalculator: FunctionComponent = () => {
   const [showEstimateShipping, setShowEstimateShipping] = useState<boolean>(
     selectedAddress && selectedAddress.postalCode ? true : false
   )
+
+  if (loading) {
+    return <Loading />
+  }
 
   return (
     <div>

--- a/react/__tests__/Shipping.test.tsx
+++ b/react/__tests__/Shipping.test.tsx
@@ -1,13 +1,12 @@
 import { render } from '@vtex/test-tools/react'
 import React from 'react'
 
-import { OrderShippingContext } from 'vtex.order-shipping/OrderShipping'
-
+import Shipping from '../Shipping'
 import ShippingCalculator from '../ShippingCalculator'
 
 interface Context {
   countries: string[]
-  selectedAddress: CheckoutAddress
+  selectedAddress: Address
   insertAddress: (address: CheckoutAddress) => void
   deliveryOptions: DeliveryOption[]
   selectDeliveryOption: (option: string) => void
@@ -45,10 +44,23 @@ const contextInfo = {
 
 describe('Shipping', () => {
   const renderComponent = (customProps: Context) => {
+    const {
+      countries,
+      deliveryOptions,
+      insertAddress,
+      selectDeliveryOption,
+      selectedAddress,
+    } = customProps
     const wrapper = render(
-      <OrderShippingContext.Provider value={customProps}>
-        <ShippingCalculator />
-      </OrderShippingContext.Provider>
+      <Shipping
+        children={<ShippingCalculator />}
+        countries={countries}
+        deliveryOptions={deliveryOptions}
+        insertAddress={insertAddress}
+        loading={false}
+        selectDeliveryOption={selectDeliveryOption}
+        selectedAddress={selectedAddress}
+      />
     )
     return wrapper
   }
@@ -70,7 +82,8 @@ describe('Shipping', () => {
 
   it('should show delivery button', () => {
     const { getByText } = renderComponent({
-      selectedAddress: {},
+      ...contextInfo,
+      selectedAddress: { addressId: '', addressType: '' },
     })
     expect(getByText('View delivery options')).toBeTruthy()
   })

--- a/store/blocks.json
+++ b/store/blocks.json
@@ -1,0 +1,5 @@
+{
+  "shipping-calculator": {
+    "children": ["estimate-shipping"]
+  }
+}

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -1,5 +1,11 @@
 {
   "shipping-calculator": {
+    "component": "Shipping",
+    "allowed": ["estimate-shipping"],
+    "composition": "children"
+  },
+
+  "estimate-shipping": {
     "component": "ShippingCalculator"
   }
 }

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -6,6 +6,11 @@
   },
 
   "estimate-shipping": {
-    "component": "ShippingCalculator"
+    "component": "ShippingCalculator",
+    "preview": {
+      "type": "box",
+      "height": 30,
+      "width": 200
+    }
   }
 }


### PR DESCRIPTION
#### Notes

This PR depends on and must be merged after [`checkout-cart`](https://github.com/vtex-apps/checkout-cart/pull/26).

<!-- Put any relevant information that doesn't fit in the other sections here. -->

#### What problem is this solving?

The loading spinner displayed on cart will be replaced by each component's preview skeleton. This PR adds `shipping-calculator` skeleton and also adapts the component to receive its necessary data through props, instead of depending on `order-shipping`.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

[Workspace](url)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] [Linked this PR to a Clubhouse story (if applicable).](https://app.clubhouse.io/vtex/story/24408/aplicar-o-skeleton-no-carregamento-do-carrinho)
- [x] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/12574426/67776238-d336a180-fa3e-11e9-92c4-2803aeb10f19.png)


#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
