### PR TITLE
Fixed not showing shipping estimate if already has postalCode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- Showing shipping estimate if has address postalCode
-- Loading estimate result and showing in the right moment
+- Showing shipping estimate if has address postalCode;
+- Loading estimate result and showing in the right moment.
+
+### Changed
+
+- ShippingInfo price with `FormattedPrice` component.
 
 ## [0.5.3] - 2019-11-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Showing shipping estimate if has address postalCode
+- Loading estimate result and showing in the right moment
 
 ## [0.5.3] - 2019-11-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Showing shipping estimate if has address postalCode
+
 ## [0.5.3] - 2019-11-08
 
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "vtex.address-form": "4.x",
     "vtex.country-codes": "2.x",
-    "vtex.format-currency": "0.x",
+    "vtex.formatted-price": "0.x",
     "vtex.styleguide": "9.x",
     "vtex.shipping-estimate-translator": "2.x"
   },

--- a/react/Shipping.tsx
+++ b/react/Shipping.tsx
@@ -13,10 +13,16 @@ defineMessages({
   },
 })
 
+
+interface InsertAddressResult {
+  success: boolean
+  orderForm: any
+}
+
 interface Context {
   countries: string[]
   deliveryOptions: DeliveryOption[]
-  insertAddress: (address: CheckoutAddress) => void
+  insertAddress: (address: CheckoutAddress) => Promise<InsertAddressResult>
   loading: boolean
   selectDeliveryOption: (option: string) => void
   selectedAddress: Address
@@ -72,7 +78,7 @@ interface ShippingProps {
   children: ReactNode
   countries: string[]
   deliveryOptions: DeliveryOption[]
-  insertAddress: (address: CheckoutAddress) => void
+  insertAddress: (address: CheckoutAddress) => Promise<InsertAddressResult>
   loading: boolean
   selectDeliveryOption: (option: string) => void
   selectedAddress: Address

--- a/react/ShippingCalculator.tsx
+++ b/react/ShippingCalculator.tsx
@@ -22,8 +22,10 @@ const ShippingCalculator: FunctionComponent = () => {
     selectedAddress,
   } = useShipping()
 
+  const shouldShowShippingEstimate = selectedAddress && !!selectedAddress.postalCode
+
   const [showEstimateShipping, setShowEstimateShipping] = useState<boolean>(
-    selectedAddress && selectedAddress.postalCode ? true : false
+    shouldShowShippingEstimate
   )
 
   if (loading) {
@@ -32,7 +34,7 @@ const ShippingCalculator: FunctionComponent = () => {
 
   return (
     <div>
-      {showEstimateShipping ? (
+      {showEstimateShipping || shouldShowShippingEstimate ? (
         <EstimateShipping
           selectedAddress={selectedAddress}
           deliveryOptions={deliveryOptions}
@@ -41,15 +43,15 @@ const ShippingCalculator: FunctionComponent = () => {
           selectDeliveryOption={selectDeliveryOption}
         />
       ) : (
-        <div>
-          <ButtonPlain
-            id="view-delivery-options"
-            onClick={() => setShowEstimateShipping(true)}
-          >
-            <FormattedMessage id="store/shipping-calculator.viewDeliveryOptions" />
-          </ButtonPlain>
-        </div>
-      )}
+          <div>
+            <ButtonPlain
+              id="view-delivery-options"
+              onClick={() => setShowEstimateShipping(true)}
+            >
+              <FormattedMessage id="store/shipping-calculator.viewDeliveryOptions" />
+            </ButtonPlain>
+          </div>
+        )}
     </div>
   )
 }

--- a/react/__mocks__/vtex.format-currency.tsx
+++ b/react/__mocks__/vtex.format-currency.tsx
@@ -1,3 +1,0 @@
-export const FormattedCurrency = () => {
-  return ''
-}

--- a/react/__mocks__/vtex.formatted-price.tsx
+++ b/react/__mocks__/vtex.formatted-price.tsx
@@ -1,0 +1,3 @@
+export const FormattedPrice = () => {
+  return ''
+}

--- a/react/components/EstimateShipping.tsx
+++ b/react/components/EstimateShipping.tsx
@@ -33,8 +33,10 @@ const EstimateShipping: FunctionComponent<CustomProps> = ({
     )
   )
 
+  const [loading, setLoading] = useState<boolean>(false)
+
   const [showResult, setShowResult] = useState<boolean>(
-    selectedAddress && selectedAddress.postalCode ? true : false
+    deliveryOptions.length > 0 && !!selectedAddress.postalCode
   )
 
   const handleAddressChange = (address: AddressWithValidation) => {
@@ -48,7 +50,7 @@ const EstimateShipping: FunctionComponent<CustomProps> = ({
 
     if (postalCodeValid) {
       insertAddress(addressWithoutValidation)
-      setShowResult(true)
+      setLoading(true)
     }
   }
 
@@ -71,10 +73,8 @@ const EstimateShipping: FunctionComponent<CustomProps> = ({
             selectDeliveryOption={selectDeliveryOption}
           />
         ) : (
-          <div>
-            <PostalCode handleSubmit={handleSubmit} countries={countries} />
-          </div>
-        )}
+            <PostalCode loading={loading} handleSubmit={handleSubmit} countries={countries} />
+          )}
       </AddressContainer>
     </AddressRules>
   )

--- a/react/components/EstimateShipping.tsx
+++ b/react/components/EstimateShipping.tsx
@@ -7,9 +7,13 @@ import { newAddress } from '../utils/address'
 
 const { AddressContainer, AddressRules, StyleguideInput } = components
 const { addValidation, removeValidation } = helpers
+interface InsertAddressResult {
+  success: boolean
+  orderForm: any
+}
 
 interface CustomProps {
-  insertAddress: (address: CheckoutAddress) => void
+  insertAddress: (address: CheckoutAddress) => Promise<InsertAddressResult>
   selectedAddress: Address
   deliveryOptions: DeliveryOption[]
   countries: string[]
@@ -49,7 +53,12 @@ const EstimateShipping: FunctionComponent<CustomProps> = ({
       address && address.postalCode && address.postalCode.valid
 
     if (postalCodeValid) {
-      insertAddress(addressWithoutValidation)
+      insertAddress(addressWithoutValidation).then((result: InsertAddressResult) => {
+        if (result.success) {
+          setShowResult(true)
+        }
+        setLoading(false)
+      })
       setLoading(true)
     }
   }

--- a/react/components/PostalCode.tsx
+++ b/react/components/PostalCode.tsx
@@ -16,7 +16,8 @@ defineMessages({
 })
 
 interface CustomProps {
-  countries: string[]
+  countries: string[],
+  loading: boolean,
   handleSubmit: () => void
 }
 
@@ -25,6 +26,7 @@ type Props = CustomProps & InjectedIntlProps
 const PostalCode: FunctionComponent<Props> = ({
   intl,
   countries,
+  loading,
   handleSubmit,
 }) => {
   const addCountryLabel = (countries: string[]) => {
@@ -51,6 +53,7 @@ const PostalCode: FunctionComponent<Props> = ({
         Button={StyleguideButton}
         submitLabel={getSubmitMessage()}
         onSubmit={handleSubmit}
+        loading={loading}
         autoFocus
       />
     </Fragment>

--- a/react/components/ShippingInfo.tsx
+++ b/react/components/ShippingInfo.tsx
@@ -1,6 +1,6 @@
 import React, { FunctionComponent } from 'react'
 import { TranslateEstimate } from 'vtex.shipping-estimate-translator'
-import { FormattedCurrency } from 'vtex.format-currency'
+import { FormattedPrice } from 'vtex.formatted-price'
 import { slugify } from '../utils/slugify'
 
 interface CustomProps {
@@ -21,7 +21,7 @@ const ShippingInfo: FunctionComponent<CustomProps> = ({ option }) => {
         </div>
       </div>
       <div id={`price-${optionId}`} className="flex-none">
-        <FormattedCurrency value={option.price / 100} />
+        <FormattedPrice value={option.price / 100} />
       </div>
     </div>
   )


### PR DESCRIPTION
#### What problem is this solving?


#### How should this be manually tested?

1. Add [items to cart](https://fernando--checkoutio.myvtex.com/cart/add?&workspace=fernando&sku=298&qty=1&seller=1&sc=1);
2. Estimate shipping and refresh;
3. It should show calculated estimate.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
