### PR TITLE
Add canEditData prop to determine whether shipping data could be edited or not

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- `shipping-calculator` now receives `canEditData` prop in order to determine whether shipping data could be edited or not.
+
 ## [0.6.0] - 2019-12-03
 
 ### Added

--- a/react/Shipping.tsx
+++ b/react/Shipping.tsx
@@ -22,6 +22,7 @@ interface InsertAddressResult {
 }
 
 interface Context {
+  canEditData: boolean
   countries: string[]
   deliveryOptions: DeliveryOption[]
   insertAddress: (address: CheckoutAddress) => Promise<InsertAddressResult>
@@ -43,6 +44,7 @@ export const useShipping = () => {
 
 const Shipping: StorefrontFunctionComponent<ShippingProps> = ({
   children,
+  canEditData,
   countries,
   deliveryOptions,
   insertAddress,
@@ -54,6 +56,7 @@ const Shipping: StorefrontFunctionComponent<ShippingProps> = ({
   return (
     <ShippingContext.Provider
       value={{
+        canEditData,
         countries,
         deliveryOptions,
         insertAddress,
@@ -73,6 +76,7 @@ const Shipping: StorefrontFunctionComponent<ShippingProps> = ({
 }
 
 Shipping.defaultProps = {
+  canEditData: false,
   countries: [],
   deliveryOptions: [],
   title: messages.delivery.id,
@@ -80,6 +84,7 @@ Shipping.defaultProps = {
 
 interface ShippingProps {
   children: ReactNode
+  canEditData: boolean
   countries: string[]
   deliveryOptions: DeliveryOption[]
   insertAddress: (address: CheckoutAddress) => Promise<InsertAddressResult>

--- a/react/ShippingCalculator.tsx
+++ b/react/ShippingCalculator.tsx
@@ -14,6 +14,7 @@ const messages = defineMessages({
 
 const ShippingCalculator: FunctionComponent = () => {
   const {
+    canEditData,
     countries,
     deliveryOptions,
     insertAddress,
@@ -37,6 +38,7 @@ const ShippingCalculator: FunctionComponent = () => {
     <div>
       {showEstimateShipping || shouldShowShippingEstimate ? (
         <EstimateShipping
+          canEditData={canEditData}
           selectedAddress={selectedAddress}
           deliveryOptions={deliveryOptions}
           countries={countries}

--- a/react/components/EstimateShipping.tsx
+++ b/react/components/EstimateShipping.tsx
@@ -13,6 +13,7 @@ interface InsertAddressResult {
 }
 
 interface CustomProps {
+  canEditData: boolean
   insertAddress: (address: CheckoutAddress) => Promise<InsertAddressResult>
   selectedAddress: Address
   deliveryOptions: DeliveryOption[]
@@ -21,6 +22,7 @@ interface CustomProps {
 }
 
 const EstimateShipping: FunctionComponent<CustomProps> = ({
+  canEditData,
   insertAddress,
   selectedAddress,
   deliveryOptions,
@@ -40,7 +42,7 @@ const EstimateShipping: FunctionComponent<CustomProps> = ({
   const [loading, setLoading] = useState<boolean>(false)
 
   const [showResult, setShowResult] = useState<boolean>(
-    deliveryOptions.length > 0 && !!selectedAddress.postalCode
+    !!selectedAddress.postalCode
   )
 
   const handleAddressChange = (address: AddressWithValidation) => {
@@ -53,12 +55,14 @@ const EstimateShipping: FunctionComponent<CustomProps> = ({
       address && address.postalCode && address.postalCode.valid
 
     if (postalCodeValid) {
-      insertAddress(addressWithoutValidation).then((result: InsertAddressResult) => {
-        if (result.success) {
-          setShowResult(true)
+      insertAddress(addressWithoutValidation).then(
+        (result: InsertAddressResult) => {
+          if (result.success) {
+            setShowResult(true)
+          }
+          setLoading(false)
         }
-        setLoading(false)
-      })
+      )
       setLoading(true)
     }
   }
@@ -76,14 +80,19 @@ const EstimateShipping: FunctionComponent<CustomProps> = ({
       >
         {showResult ? (
           <ShippingResult
+            canEditData={canEditData}
             address={address}
             options={deliveryOptions}
             setShowResult={setShowResult}
             selectDeliveryOption={selectDeliveryOption}
           />
         ) : (
-            <PostalCode loading={loading} handleSubmit={handleSubmit} countries={countries} />
-          )}
+          <PostalCode
+            loading={loading}
+            handleSubmit={handleSubmit}
+            countries={countries}
+          />
+        )}
       </AddressContainer>
     </AddressRules>
   )

--- a/react/components/EstimateShipping.tsx
+++ b/react/components/EstimateShipping.tsx
@@ -42,7 +42,7 @@ const EstimateShipping: FunctionComponent<CustomProps> = ({
   const [loading, setLoading] = useState<boolean>(false)
 
   const [showResult, setShowResult] = useState<boolean>(
-    !!selectedAddress.postalCode
+    selectedAddress && !!selectedAddress.postalCode
   )
 
   const handleAddressChange = (address: AddressWithValidation) => {

--- a/react/components/ShippingResult.tsx
+++ b/react/components/ShippingResult.tsx
@@ -18,6 +18,7 @@ defineMessages({
 
 interface CustomProps {
   address: AddressWithValidation
+  canEditData: boolean
   options: DeliveryOption[]
   setShowResult: (showResult: boolean) => void
   selectDeliveryOption: (option: string) => void
@@ -25,6 +26,7 @@ interface CustomProps {
 
 const ShippingResult: FunctionComponent<CustomProps> = ({
   address,
+  canEditData,
   options,
   setShowResult,
   selectDeliveryOption,
@@ -40,14 +42,16 @@ const ShippingResult: FunctionComponent<CustomProps> = ({
           </span>{' '}
           {postalCode}
         </div>
-        <div className="flex-none">
-          <ButtonPlain
-            id="edit-shipping"
-            onClick={() => setShowResult(false)}
-          >
-            <FormattedMessage id="store/shipping-calculator.edit" />
-          </ButtonPlain>
-        </div>
+        {canEditData && (
+          <div className="flex-none">
+            <ButtonPlain
+              id="edit-shipping"
+              onClick={() => setShowResult(false)}
+            >
+              <FormattedMessage id="store/shipping-calculator.edit" />
+            </ButtonPlain>
+          </div>
+        )}
       </div>
       <ShippingOptions
         options={options}


### PR DESCRIPTION
#### What problem is this solving?

As the title says.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

- Proceed to [Workspace](https://fixskeleton--checkoutio.myvtex.com/cart).
- Verify that edit postal code button isn't available.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] [Linked this PR to a Clubhouse story (if applicable).](https://app.clubhouse.io/vtex/story/27047/remover-a-op%C3%A7%C3%A3o-de-alterar-cep-no-carrinho-quando-usu%C3%A1rio-estiver-identificado)
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️| New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

