### PR TITLE
Fix calculate button not working after edit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Calculate button not working when user didn't edit the zipcode after entering edit mode.
 
 ## [0.8.2] - 2020-02-12
 ### Changed

--- a/react/components/EstimateShipping.tsx
+++ b/react/components/EstimateShipping.tsx
@@ -83,6 +83,7 @@ const EstimateShipping: FunctionComponent<CustomProps> = ({
         address={address}
         Input={StyleguideInput}
         onChangeAddress={handleAddressChange}
+        shouldHandleAddressChangeOnMount
       >
         {showResult ? (
           <ShippingResult


### PR DESCRIPTION
#### What problem is this solving?
Sometimes, when you clicked to edit the zipcode and didn't edit the value in the input, the "calculate" button wouldn't do anything when pressed.

[Clubhouse story](https://app.clubhouse.io/vtex/story/27287/corrigir-erro-ao-clicar-em-alterar-cep-e-manter-o-mesmo-valor-para-c%C3%A1lculo-das-op%C3%A7%C3%B5es).

#### How should this be manually tested?
[Workspace](https://lucas2--checkoutio.myvtex.com/cart)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->