### PR TITLE
CHK-425: Fix regression of id in view delivery options button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Added back id `view-delivery-options` to button in `ShippingCalculator`.
 
 ## [0.9.0] - 2020-11-04
 ### Changed

--- a/react/ShippingCalculator.tsx
+++ b/react/ShippingCalculator.tsx
@@ -36,7 +36,10 @@ const ShippingCalculator: React.VFC = () => {
   if (!showShippingEstimate) {
     return (
       <div>
-        <ButtonPlain onClick={() => setShowShippingEstimate(true)}>
+        <ButtonPlain
+          id="view-delivery-options"
+          onClick={() => setShowShippingEstimate(true)}
+        >
           <FormattedMessage id="store/shipping-calculator.viewDeliveryOptions" />
         </ButtonPlain>
       </div>


### PR DESCRIPTION
#### What problem is this solving?

This PR adds back the id to the "View delivery options" button that was removed in a previous PR, our e2e tests rely on this id to function correctly.

#### How to test it?

[Workspace](https://lucas--checkoutio.myvtex.com/cart).

Check that the id on the button is showing correctly. (You may need to access this page as a anonymous user, so you can use [this link](https://checkoutio.myvtexprod.com/cart?workspace=lucas), but note that since this is using a prod cluster on a dev workspace some timeout errors will be more frequent and queries will be slower).

#### Screenshots or example usage:

#### Describe alternatives you've considered, if any.

N/A

#### Related to / Depends on

N/A
